### PR TITLE
UHM-9421: Multi-select Order Status filter on Lab Order List

### DIFF
--- a/api/src/main/java/org/openmrs/module/pihapps/PihAppsServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/pihapps/PihAppsServiceImpl.java
@@ -275,6 +275,9 @@ public class PihAppsServiceImpl extends BaseOpenmrsService implements PihAppsSer
 		if (searchCriteria.getOrderFulfillmentStatuses() != null && !searchCriteria.getOrderFulfillmentStatuses().isEmpty()) {
 			List<Criterion> statusCriteria = new ArrayList<>();
 			for (OrderFulfillmentStatus status : searchCriteria.getOrderFulfillmentStatuses()) {
+				if (status == null) {
+					continue;
+				}
 				Criterion orderStatusClause = null;
 				if (status.getOrderStatus() == OrderStatus.ACTIVE) {
 					Criterion orderIsNotExpired = or(isNull("autoExpireDate"), gt("autoExpireDate", now));

--- a/api/src/main/java/org/openmrs/module/pihapps/PihAppsServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/pihapps/PihAppsServiceImpl.java
@@ -41,6 +41,7 @@ import org.openmrs.module.pihapps.obs.ObsSearchCriteria;
 import org.openmrs.module.pihapps.obs.ObsSearchResult;
 import org.openmrs.module.pihapps.orders.EncounterFulfillingOrders;
 import org.openmrs.module.pihapps.orders.LabOrderConfig;
+import org.openmrs.module.pihapps.orders.OrderFulfillmentStatus;
 import org.openmrs.module.pihapps.orders.OrderSearchCriteria;
 import org.openmrs.module.pihapps.orders.OrderSearchResult;
 import org.openmrs.module.pihapps.orders.OrderStatus;
@@ -271,38 +272,53 @@ public class PihAppsServiceImpl extends BaseOpenmrsService implements PihAppsSer
 			Date onOrAfter = OpenmrsUtil.firstSecondOfDay(searchCriteria.getActivatedOnOrAfter());
 			c.add(ge("dateActivated", onOrAfter));
 		}
-		if (searchCriteria.getOrderStatus() != null && !searchCriteria.getOrderStatus().isEmpty()) {
-			Criterion[] orderStatusCriteria = new Criterion[searchCriteria.getOrderStatus().size()];
-			for (int i = 0; i < searchCriteria.getOrderStatus().size(); i++) {
-				OrderStatus orderStatus = searchCriteria.getOrderStatus().get(i);
-				if (orderStatus == OrderStatus.ACTIVE) {
+		if (searchCriteria.getOrderFulfillmentStatuses() != null && !searchCriteria.getOrderFulfillmentStatuses().isEmpty()) {
+			List<Criterion> statusCriteria = new ArrayList<>();
+			for (OrderFulfillmentStatus status : searchCriteria.getOrderFulfillmentStatuses()) {
+				Criterion orderStatusClause = null;
+				if (status.getOrderStatus() == OrderStatus.ACTIVE) {
 					Criterion orderIsNotExpired = or(isNull("autoExpireDate"), gt("autoExpireDate", now));
 					Criterion orderIsNotStopped = or(isNull("dateStopped")); // This should never be in the future
-					orderStatusCriteria[i] = and(orderIsNotExpired, orderIsNotStopped);
+					orderStatusClause = and(orderIsNotExpired, orderIsNotStopped);
 				}
-				else if (orderStatus == OrderStatus.EXPIRED) {
-					orderStatusCriteria[i] = le("autoExpireDate", now);
+				else if (status.getOrderStatus() == OrderStatus.EXPIRED) {
+					orderStatusClause = le("autoExpireDate", now);
 				}
-				else if (orderStatus == OrderStatus.STOPPED) {
-					orderStatusCriteria[i] = isNotNull("dateStopped");
+				else if (status.getOrderStatus() == OrderStatus.STOPPED) {
+					orderStatusClause = isNotNull("dateStopped");
+				}
+
+				List<Criterion> fulfillerStatusClauses = new ArrayList<>();
+				if (status.getFulfillerStatuses() != null) {
+					for (Order.FulfillerStatus fulfillerStatus : status.getFulfillerStatuses()) {
+						fulfillerStatusClauses.add(eq("fulfillerStatus", fulfillerStatus));
+					}
+				}
+				if (status.getIncludeNullFulfillerStatus() == Boolean.TRUE) {
+					fulfillerStatusClauses.add(isNull("fulfillerStatus"));
+				}
+				else if (status.getIncludeNullFulfillerStatus() == Boolean.FALSE) {
+					fulfillerStatusClauses.add(isNotNull("fulfillerStatus"));
+				}
+				Criterion fulfillerStatusClause = fulfillerStatusClauses.isEmpty() ? null : or(fulfillerStatusClauses.toArray(new Criterion[0]));
+
+				Criterion statusCriterion;
+				if (orderStatusClause != null && fulfillerStatusClause != null) {
+					statusCriterion = and(orderStatusClause, fulfillerStatusClause);
+				}
+				else if (orderStatusClause != null) {
+					statusCriterion = orderStatusClause;
+				}
+				else {
+					statusCriterion = fulfillerStatusClause;
+				}
+				if (statusCriterion != null) {
+					statusCriteria.add(statusCriterion);
 				}
 			}
-			c.add(or(orderStatusCriteria));
-		}
-		List<Criterion> fulfillerStatusCriteria = new ArrayList<>();
-		if (searchCriteria.getFulfillerStatuses() != null && !searchCriteria.getFulfillerStatuses().isEmpty()) {
-			for (Order.FulfillerStatus fulfillerStatus : searchCriteria.getFulfillerStatuses()) {
-				fulfillerStatusCriteria.add(eq("fulfillerStatus", fulfillerStatus));
+			if (!statusCriteria.isEmpty()) {
+				c.add(or(statusCriteria.toArray(new Criterion[0])));
 			}
-		}
-		if (searchCriteria.getIncludeNullFulfillerStatus() == Boolean.TRUE) {
-			fulfillerStatusCriteria.add(isNull("fulfillerStatus"));
-		}
-		else if (searchCriteria.getIncludeNullFulfillerStatus() == Boolean.FALSE) {
-			fulfillerStatusCriteria.add(isNotNull("fulfillerStatus"));
-		}
-		if (!fulfillerStatusCriteria.isEmpty()) {
-			c.add(or(fulfillerStatusCriteria.toArray(new Criterion[0])));
 		}
 
 		if (applySortCriteria) {

--- a/api/src/main/java/org/openmrs/module/pihapps/orders/LabOrderConfig.java
+++ b/api/src/main/java/org/openmrs/module/pihapps/orders/LabOrderConfig.java
@@ -64,7 +64,6 @@ public class LabOrderConfig {
 
     public List<Map<String, String>> getOrderFulfillmentStatusOptions() {
         List<Map<String, String>> l = new ArrayList<>();
-        l.add(map("status", "", "display", messageSourceService.getMessage("pihapps.all")));
         for (OrderFulfillmentStatus s : OrderFulfillmentStatus.values()) {
             String display = messageSourceService.getMessage("pihapps.orderFulfillmentStatus." + s.name());
             l.add(map("status", s.name(), "display", display));

--- a/api/src/main/java/org/openmrs/module/pihapps/orders/OrderSearchCriteria.java
+++ b/api/src/main/java/org/openmrs/module/pihapps/orders/OrderSearchCriteria.java
@@ -3,7 +3,6 @@ package org.openmrs.module.pihapps.orders;
 import lombok.Data;
 import org.openmrs.Concept;
 import org.openmrs.Location;
-import org.openmrs.Order;
 import org.openmrs.OrderType;
 import org.openmrs.Patient;
 import org.openmrs.module.pihapps.SortCriteria;
@@ -21,9 +20,7 @@ public class OrderSearchCriteria {
     private List<String> orderNumbers;
     private Date activatedOnOrBefore;
     private Date activatedOnOrAfter;
-    private List<OrderStatus> orderStatus;
-    private List<Order.FulfillerStatus> fulfillerStatuses;
-    private Boolean includeNullFulfillerStatus;
+    private List<OrderFulfillmentStatus> orderFulfillmentStatuses;
     private List<SortCriteria> sortCriteria;
     private Integer startIndex;
     private Integer limit;

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -56,6 +56,7 @@ pihapps.patient=Patient
 pihapps.orderedFrom=Ordered From
 pihapps.orderedTo=Ordered To
 pihapps.orderStatus=Order Status
+pihapps.allStatuses=All Statuses
 pihapps.fulfillerStatus=Lab Status
 pihapps.all=All
 pihapps.none=None

--- a/api/src/main/resources/messages_es.properties
+++ b/api/src/main/resources/messages_es.properties
@@ -56,6 +56,7 @@ pihapps.patient=Patient
 pihapps.orderedFrom=Desde la fecha del pedido
 pihapps.orderedTo=Hasta la fecha del pedido
 pihapps.orderStatus=Estado del pedido
+pihapps.allStatuses=Todos los estados
 pihapps.fulfillerStatus=Estado del laboratorio
 pihapps.all=Todas
 pihapps.none=Ninguna

--- a/api/src/main/resources/messages_fr.properties
+++ b/api/src/main/resources/messages_fr.properties
@@ -56,6 +56,7 @@ pihapps.patient=Patient
 pihapps.orderedFrom=À compter de la date
 pihapps.orderedTo=Jusqu'à la date
 pihapps.orderStatus=État de la commande
+pihapps.allStatuses=Tous les statuts
 pihapps.fulfillerStatus=État du laboratoire
 pihapps.all=Tout
 pihapps.none=Aucune

--- a/api/src/test/java/org/openmrs/module/pihapps/PihAppsServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/pihapps/PihAppsServiceTest.java
@@ -15,6 +15,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -178,13 +179,17 @@ public class PihAppsServiceTest extends BaseModuleContextSensitiveTest {
 
         OrderSearchCriteria criteria = new OrderSearchCriteria();
         criteria.setOrderTypes(Collections.singletonList(labOrderConfig.getLabTestOrderType()));
-        applyFulfillmentStatus(criteria, OrderFulfillmentStatus.IN_FULFILLMENT);
+        criteria.setOrderFulfillmentStatuses(Collections.singletonList(OrderFulfillmentStatus.IN_FULFILLMENT));
 
         OrderSearchResult result = pihAppsService.getOrders(criteria);
 
-        // Only order 102 (IN_PROGRESS) should match; standard dataset has none with IN_PROGRESS
-        assertThat(result.getTotalCount(), equalTo(1L));
-        assertThat(result.getOrders().get(0).getFulfillerStatus(), equalTo(Order.FulfillerStatus.IN_PROGRESS));
+        // Orders 102 and 103 (both IN_PROGRESS) should match; standard dataset has none with IN_PROGRESS.
+        // Order 103 is also order-level STOPPED, but IN_FULFILLMENT has no order-status constraint
+        // (only a fulfiller-status constraint), so it still matches.
+        assertThat(result.getTotalCount(), equalTo(2L));
+        for (Order order : result.getOrders()) {
+            assertThat(order.getFulfillerStatus(), equalTo(Order.FulfillerStatus.IN_PROGRESS));
+        }
     }
 
     @Test
@@ -192,7 +197,7 @@ public class PihAppsServiceTest extends BaseModuleContextSensitiveTest {
         // Standard dataset order 7: patient 2, RECEIVED, active → AWAITING_FULFILLMENT
         OrderSearchCriteria criteria = new OrderSearchCriteria();
         criteria.setOrderTypes(Collections.singletonList(labOrderConfig.getLabTestOrderType()));
-        applyFulfillmentStatus(criteria, OrderFulfillmentStatus.AWAITING_FULFILLMENT);
+        criteria.setOrderFulfillmentStatuses(Collections.singletonList(OrderFulfillmentStatus.AWAITING_FULFILLMENT));
 
         OrderSearchResult result = pihAppsService.getOrders(criteria);
 
@@ -211,7 +216,7 @@ public class PihAppsServiceTest extends BaseModuleContextSensitiveTest {
         // Standard dataset order 6: patient 2, COMPLETED
         OrderSearchCriteria criteria = new OrderSearchCriteria();
         criteria.setOrderTypes(Collections.singletonList(labOrderConfig.getLabTestOrderType()));
-        applyFulfillmentStatus(criteria, OrderFulfillmentStatus.COMPLETED_FULFILLMENT);
+        criteria.setOrderFulfillmentStatuses(Collections.singletonList(OrderFulfillmentStatus.COMPLETED_FULFILLMENT));
 
         OrderSearchResult result = pihAppsService.getOrders(criteria);
 
@@ -221,12 +226,32 @@ public class PihAppsServiceTest extends BaseModuleContextSensitiveTest {
         }
     }
 
-    private void applyFulfillmentStatus(OrderSearchCriteria criteria, OrderFulfillmentStatus status) {
-        if (status.getOrderStatus() != null) {
-            criteria.setOrderStatus(Collections.singletonList(status.getOrderStatus()));
+    @Test
+    public void getOrders_shouldFilterByMultipleFulfillmentStatusesIndependently() throws Exception {
+        executeDataSet("pihapps_lab_order_test_data.xml");
+
+        OrderSearchCriteria criteria = new OrderSearchCriteria();
+        criteria.setOrderTypes(Collections.singletonList(labOrderConfig.getLabTestOrderType()));
+        criteria.setOrderFulfillmentStatuses(Arrays.asList(
+                OrderFulfillmentStatus.AWAITING_FULFILLMENT, OrderFulfillmentStatus.IN_FULFILLMENT));
+
+        OrderSearchResult result = pihAppsService.getOrders(criteria);
+
+        // Order 103 has fulfillerStatus=IN_PROGRESS (Collected) but dateStopped set (order-level STOPPED).
+        // It must still match IN_FULFILLMENT: combining statuses must evaluate each independently rather
+        // than ANDing a shared orderStatus across both, which would wrongly require ACTIVE for this order too.
+        boolean order103Matched = result.getOrders().stream()
+                .anyMatch(o -> "c3d4e5f6-a7b8-9012-cdef-123456789012".equals(o.getUuid()));
+        assertThat("collected-then-stopped order must still match IN_FULFILLMENT", order103Matched, equalTo(true));
+
+        for (Order order : result.getOrders()) {
+            boolean matchesAwaiting = order.getDateStopped() == null
+                    && (order.getFulfillerStatus() == null || order.getFulfillerStatus() == Order.FulfillerStatus.RECEIVED);
+            boolean matchesInFulfillment = order.getFulfillerStatus() == Order.FulfillerStatus.IN_PROGRESS
+                    || order.getFulfillerStatus() == Order.FulfillerStatus.ON_HOLD;
+            assertThat("every returned order must independently satisfy AWAITING or IN_FULFILLMENT",
+                    matchesAwaiting || matchesInFulfillment, equalTo(true));
         }
-        criteria.setFulfillerStatuses(status.getFulfillerStatuses());
-        criteria.setIncludeNullFulfillerStatus(status.getIncludeNullFulfillerStatus());
     }
 
     void printResult(OrderSearchResult result) {

--- a/api/src/test/resources/pihapps_lab_order_test_data.xml
+++ b/api/src/test/resources/pihapps_lab_order_test_data.xml
@@ -11,6 +11,8 @@
   Added here:
     order 101: patient 7, STAT,    no fulfiller_status → AWAITING_FULFILLMENT  (gives patient 7 a higher urgency than patient 2)
     order 102: patient 2, ROUTINE, fulfiller_status=IN_PROGRESS                → IN_FULFILLMENT
+    order 103: patient 2, ROUTINE, fulfiller_status=IN_PROGRESS, date_stopped  → IN_FULFILLMENT
+               (collected, then later discontinued — order-level STOPPED must NOT exclude it from IN_FULFILLMENT)
 
   Encounter 3 is patient 7's. Encounter 6 is patient 2's.
   All use care_setting 1 (OUTPATIENT), orderer 1, concept 5497, order_type 2 (Test order).
@@ -48,6 +50,25 @@
             voided="false"
             patient_id="2"
             uuid="b2c3d4e5-f6a7-8901-bcde-f12345678901"
+            care_setting="1"
+            encounter_id="6" />
+
+    <!-- IN_PROGRESS order for patient 2, later stopped: must still appear in IN_FULFILLMENT filter -->
+    <orders order_id="103"
+            order_type_id="2"
+            order_number="ORD-103"
+            urgency="ROUTINE"
+            order_action="NEW"
+            concept_id="5497"
+            orderer="1"
+            fulfiller_status="IN_PROGRESS"
+            date_activated="2009-01-15 10:00:00.0"
+            date_stopped="2009-01-16 10:00:00.0"
+            creator="1"
+            date_created="2009-01-15 10:00:00.0"
+            voided="false"
+            patient_id="2"
+            uuid="c3d4e5f6-a7b8-9012-cdef-123456789012"
             care_setting="1"
             encounter_id="6" />
 </dataset>

--- a/docs/labs-technical.md
+++ b/docs/labs-technical.md
@@ -144,7 +144,7 @@ Searches orders with pagination. Delegates to `PihAppsService.getOrders(OrderSea
 | `activatedOnOrAfter` | `yyyy-MM-dd` | |
 | `activatedOnOrBefore` | `yyyy-MM-dd` | |
 | `accessionNumber` | string | |
-| `orderFulfillmentStatus` | `OrderFulfillmentStatus` enum name | |
+| `orderFulfillmentStatus` | `OrderFulfillmentStatus` enum name (repeatable) | |
 | `sortBy` | `field-DIRECTION` (repeatable) | e.g. `dateActivated-desc` |
 | `v` | custom representation | Standard OpenMRS REST `v` param |
 | `startIndex`, `limit` | int | Pagination |

--- a/omod/src/main/java/org/openmrs/module/pihapps/rest/LabOrderRestController.java
+++ b/omod/src/main/java/org/openmrs/module/pihapps/rest/LabOrderRestController.java
@@ -96,11 +96,7 @@ public class LabOrderRestController {
             searchCriteria.setActivatedOnOrBefore(getDate(activatedOnOrBefore));
             searchCriteria.setActivatedOnOrAfter(getDate(activatedOnOrAfter));
             if (orderFulfillmentStatus != null) {
-                if (orderFulfillmentStatus.getOrderStatus() != null) {
-                    searchCriteria.setOrderStatus(Collections.singletonList(orderFulfillmentStatus.getOrderStatus()));
-                }
-                searchCriteria.setFulfillerStatuses(orderFulfillmentStatus.getFulfillerStatuses());
-                searchCriteria.setIncludeNullFulfillerStatus(orderFulfillmentStatus.getIncludeNullFulfillerStatus());
+                searchCriteria.setOrderFulfillmentStatuses(Collections.singletonList(orderFulfillmentStatus));
             }
             searchCriteria.setStartIndex(requestContext.getStartIndex());
             searchCriteria.setLimit(requestContext.getLimit());
@@ -169,11 +165,7 @@ public class LabOrderRestController {
             searchCriteria.setActivatedOnOrBefore(getDate(activatedOnOrBefore));
             searchCriteria.setActivatedOnOrAfter(getDate(activatedOnOrAfter));
             if (orderFulfillmentStatus != null) {
-                if (orderFulfillmentStatus.getOrderStatus() != null) {
-                    searchCriteria.setOrderStatus(Collections.singletonList(orderFulfillmentStatus.getOrderStatus()));
-                }
-                searchCriteria.setFulfillerStatuses(orderFulfillmentStatus.getFulfillerStatuses());
-                searchCriteria.setIncludeNullFulfillerStatus(orderFulfillmentStatus.getIncludeNullFulfillerStatus());
+                searchCriteria.setOrderFulfillmentStatuses(Collections.singletonList(orderFulfillmentStatus));
             }
             searchCriteria.setStartIndex(requestContext.getStartIndex());
             searchCriteria.setLimit(requestContext.getLimit());

--- a/omod/src/main/java/org/openmrs/module/pihapps/rest/LabOrderRestController.java
+++ b/omod/src/main/java/org/openmrs/module/pihapps/rest/LabOrderRestController.java
@@ -40,7 +40,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
@@ -78,7 +77,7 @@ public class LabOrderRestController {
                                @RequestParam(value = "activatedOnOrBefore", required = false) String activatedOnOrBefore,
                                @RequestParam(value = "activatedOnOrAfter", required = false) String activatedOnOrAfter,
                                @RequestParam(value = "accessionNumber", required = false) String accessionNumber,
-                               @RequestParam(value = "orderFulfillmentStatus", required = false) OrderFulfillmentStatus orderFulfillmentStatus,
+                               @RequestParam(value = "orderFulfillmentStatus", required = false) List<OrderFulfillmentStatus> orderFulfillmentStatus,
                                @RequestParam(value = "sortBy", required = false) List<String> sortBy
                                ) throws ResponseException {
 
@@ -95,9 +94,7 @@ public class LabOrderRestController {
             searchCriteria.setAccessionNumber(accessionNumber);
             searchCriteria.setActivatedOnOrBefore(getDate(activatedOnOrBefore));
             searchCriteria.setActivatedOnOrAfter(getDate(activatedOnOrAfter));
-            if (orderFulfillmentStatus != null) {
-                searchCriteria.setOrderFulfillmentStatuses(Collections.singletonList(orderFulfillmentStatus));
-            }
+            searchCriteria.setOrderFulfillmentStatuses(orderFulfillmentStatus);
             searchCriteria.setStartIndex(requestContext.getStartIndex());
             searchCriteria.setLimit(requestContext.getLimit());
 
@@ -147,7 +144,7 @@ public class LabOrderRestController {
                                @RequestParam(value = "activatedOnOrBefore", required = false) String activatedOnOrBefore,
                                @RequestParam(value = "activatedOnOrAfter", required = false) String activatedOnOrAfter,
                                @RequestParam(value = "accessionNumber", required = false) String accessionNumber,
-                               @RequestParam(value = "orderFulfillmentStatus", required = false) OrderFulfillmentStatus orderFulfillmentStatus,
+                               @RequestParam(value = "orderFulfillmentStatus", required = false) List<OrderFulfillmentStatus> orderFulfillmentStatus,
                                @RequestParam(value = "sortBy", required = false) List<String> sortBy
     ) throws ResponseException {
 
@@ -164,9 +161,7 @@ public class LabOrderRestController {
             searchCriteria.setAccessionNumber(accessionNumber);
             searchCriteria.setActivatedOnOrBefore(getDate(activatedOnOrBefore));
             searchCriteria.setActivatedOnOrAfter(getDate(activatedOnOrAfter));
-            if (orderFulfillmentStatus != null) {
-                searchCriteria.setOrderFulfillmentStatuses(Collections.singletonList(orderFulfillmentStatus));
-            }
+            searchCriteria.setOrderFulfillmentStatuses(orderFulfillmentStatus);
             searchCriteria.setStartIndex(requestContext.getStartIndex());
             searchCriteria.setLimit(requestContext.getLimit());
 

--- a/omod/src/main/webapp/pages/labs/labOrderList.gsp
+++ b/omod/src/main/webapp/pages/labs/labOrderList.gsp
@@ -654,7 +654,7 @@
                 jq("#orderFulfillmentStatus-filter-menu").toggleClass("show");
             });
             jq(document).on("click", (event) => {
-                if (!jq(event.target).closest("#orderFulfillmentStatus-filter-menu, #orderFulfillmentStatus-filter-toggle").length) {
+                if (!jq(event.target).closest("#orderFulfillmentStatus-filter-menu, #orderFulfillmentStatus-filter-toggle, #orderFulfillmentStatus-filter-label").length) {
                     jq("#orderFulfillmentStatus-filter-menu").removeClass("show");
                 }
             });
@@ -781,7 +781,7 @@
                 ])}
             </div>
             <div class="col">
-                <label for="orderFulfillmentStatus-filter-toggle">${ ui.message("pihapps.orderStatus") }</label>
+                <label for="orderFulfillmentStatus-filter-toggle" id="orderFulfillmentStatus-filter-label">${ ui.message("pihapps.orderStatus") }</label>
                 <div class="status-filter-dropdown-wrapper">
                     <button type="button" id="orderFulfillmentStatus-filter-toggle" class="form-control status-filter-dropdown-toggle">
                         <span id="orderFulfillmentStatus-filter-summary"></span>

--- a/omod/src/main/webapp/pages/labs/labOrderList.gsp
+++ b/omod/src/main/webapp/pages/labs/labOrderList.gsp
@@ -134,7 +134,7 @@
         // Read URL params for deep linking (e.g., Specimen Collection Queue)
         const urlParams = new URLSearchParams(window.location.search);
         const initialGrouping = urlParams.get('grouping');   // 'patient' or null
-        const initialStatus = urlParams.get('status');        // e.g. 'AWAITING_FULFILLMENT' or null
+        const initialStatuses = urlParams.getAll('status');   // e.g. ['AWAITING_FULFILLMENT', 'IN_FULFILLMENT'] or []
 
         jq.get(openmrsContextPath + "/ws/rest/v1/pihapps/config?v=custom:(" + pihAppsConfigRep + ")", function(pihAppsConfig) {
 
@@ -229,9 +229,17 @@
                     "activatedOnOrAfter": jq("#orderedFrom-filter-field").val(),
                     "activatedOnOrBefore": jq("#orderedTo-filter-field").val(),
                     "accessionNumber": jq("#lab-id-filter").val(),
-                    "orderFulfillmentStatus": jq("#orderFulfillmentStatus-filter").val(),
+                    "orderFulfillmentStatus": jq(".orderFulfillmentStatus-checkbox:checked").map((i, el) => jq(el).val()).get(),
                     "sortBy": "dateActivated-desc"  // TODO: Sorting by dateActivated desc does not seem right, but doing this to match existing labWorkflow, but shouldn't this order by urgency and asc?
                 }
+            }
+
+            const updateOrderFulfillmentStatusSummary = function() {
+                const checked = jq(".orderFulfillmentStatus-checkbox:checked");
+                const summary = checked.length === 0
+                    ? "${ ui.encodeJavaScript(ui.message('pihapps.allStatuses')) }"
+                    : checked.map((i, el) => jq(el).data("display")).get().join(", ");
+                jq("#orderFulfillmentStatus-filter-summary").text(summary);
             }
 
             const orderTableUpdated = function() {
@@ -523,9 +531,19 @@
             });
 
             orderFulfillmentStatusOptions.forEach((statusOption) => {
-                const option = jq("<option>").attr("value", statusOption.status).html(statusOption.display);
-                jq("#orderFulfillmentStatus-filter").append(option);
+                const checkboxId = "orderFulfillmentStatus-option-" + statusOption.status;
+                const checkbox = jq("<input>").attr({
+                    type: "checkbox",
+                    id: checkboxId,
+                    value: statusOption.status,
+                    "data-display": statusOption.display
+                }).addClass("orderFulfillmentStatus-checkbox");
+                const optionLabel = jq("<label>").addClass("status-filter-option").attr("for", checkboxId)
+                    .append(checkbox).append(" " + statusOption.display);
+                jq("#orderFulfillmentStatus-filter-menu").append(optionLabel);
             });
+            jq(".orderFulfillmentStatus-checkbox").on("change", updateOrderFulfillmentStatusSummary);
+            updateOrderFulfillmentStatusSummary();
 
             if (visitLocationUuid) {
                 const locationRep = "custom:(uuid,display,descendantLocations:(uuid,display,tags:(uuid,name)))";
@@ -615,16 +633,37 @@
                 return pagingDataTable.getRowObjects().find((o) => o.uuid === orderUuid);
             }
 
-            // Apply initial status from URL param, if present
-            if (initialStatus) {
-                jq("#orderFulfillmentStatus-filter").val(initialStatus).trigger("change");
-            }
+            // Apply initial status filter: URL param(s) if present, otherwise default to Ordered + Collected
+            const defaultFulfillmentStatuses = ["AWAITING_FULFILLMENT", "IN_FULFILLMENT"];
+            const statusesToApply = initialStatuses.length > 0 ? initialStatuses : defaultFulfillmentStatuses;
+            jq(".orderFulfillmentStatus-checkbox").prop("checked", function() {
+                return statusesToApply.includes(jq(this).val());
+            });
+            updateOrderFulfillmentStatusSummary();
+            jq(".orderFulfillmentStatus-checkbox").first().trigger("change");
 
             // Add clear buttons to filters
             jq(".clearable-input-wrapper").find(".icon-remove").on("click", (event) => {
                 const icon = jq(event.target);
                 icon.siblings(".clearable-input").val("").change();
             })
+
+            // Order status dropdown: open/close toggle, outside-click to close, clear-all
+            jq("#orderFulfillmentStatus-filter-toggle").on("click", (event) => {
+                event.stopPropagation();
+                jq("#orderFulfillmentStatus-filter-menu").toggleClass("show");
+            });
+            jq(document).on("click", (event) => {
+                if (!jq(event.target).closest("#orderFulfillmentStatus-filter-menu, #orderFulfillmentStatus-filter-toggle").length) {
+                    jq("#orderFulfillmentStatus-filter-menu").removeClass("show");
+                }
+            });
+            jq("#orderFulfillmentStatus-filter-clear").on("click", (event) => {
+                event.stopPropagation();
+                jq(".orderFulfillmentStatus-checkbox").prop("checked", false);
+                updateOrderFulfillmentStatusSummary();
+                jq(".orderFulfillmentStatus-checkbox").first().trigger("change");
+            });
         });
     });
 </script>
@@ -742,10 +781,13 @@
                 ])}
             </div>
             <div class="col">
-                <label for="orderFulfillmentStatus-filter">${ ui.message("pihapps.orderStatus") }</label>
-                <div class="clearable-input-wrapper">
-                    <select id="orderFulfillmentStatus-filter" name="orderFulfillmentStatus" class="clearable-input"></select>
-                    <i class="icon-remove small"></i>
+                <label for="orderFulfillmentStatus-filter-toggle">${ ui.message("pihapps.orderStatus") }</label>
+                <div class="status-filter-dropdown-wrapper">
+                    <button type="button" id="orderFulfillmentStatus-filter-toggle" class="form-control status-filter-dropdown-toggle">
+                        <span id="orderFulfillmentStatus-filter-summary"></span>
+                    </button>
+                    <i class="icon-remove small status-filter-clear" id="orderFulfillmentStatus-filter-clear"></i>
+                    <div id="orderFulfillmentStatus-filter-menu" class="status-filter-dropdown-menu"></div>
                 </div>
             </div>
             <div class="col">

--- a/omod/src/main/webapp/pages/labs/labOrderList.gsp
+++ b/omod/src/main/webapp/pages/labs/labOrderList.gsp
@@ -253,6 +253,21 @@
                 }
             }
 
+            // The menu is appended to <body> (see below) so it can't be clipped or covered by
+            // ancestor stacking/overflow rules from shared page-layout CSS outside this module's
+            // control — the same technique jQuery UI's autocomplete widget already uses on this
+            // page (it defaults to appendTo: "body"). Since it's no longer positioned relative to
+            // its original wrapper, its screen position is computed from the toggle button instead.
+            const positionOrderFulfillmentStatusMenu = function() {
+                const toggle = jq("#orderFulfillmentStatus-filter-toggle");
+                const offset = toggle.offset();
+                jq("#orderFulfillmentStatus-filter-menu").css({
+                    top: (offset.top + toggle.outerHeight()) + "px",
+                    left: offset.left + "px",
+                    minWidth: toggle.outerWidth() + "px"
+                });
+            }
+
             const orderTableUpdated = function() {
                 jq(".enter-results-action").off("click").on("click", (event) => {
                     const orderUuid = jq(event.target).data().orderUuid;
@@ -518,7 +533,11 @@
                     .append(checkbox).append(" " + statusOption.display);
                 jq("#orderFulfillmentStatus-filter-menu").append(optionLabel);
             });
-            jq(".orderFulfillmentStatus-checkbox").on("change", updateOrderFulfillmentStatusSummary);
+            jq("#orderFulfillmentStatus-filter-menu").appendTo("body");
+            jq(".orderFulfillmentStatus-checkbox").on("change", () => {
+                updateOrderFulfillmentStatusSummary();
+                refreshActiveTable();
+            });
             updateOrderFulfillmentStatusSummary();
 
             // Apply initial status filter: URL param(s) if present, otherwise default to Ordered + Collected
@@ -652,7 +671,11 @@
             // Order status dropdown: open/close toggle, outside-click to close, clear-all
             jq("#orderFulfillmentStatus-filter-toggle").on("click", (event) => {
                 event.stopPropagation();
-                jq("#orderFulfillmentStatus-filter-menu").toggleClass("show");
+                const menu = jq("#orderFulfillmentStatus-filter-menu");
+                if (!menu.hasClass("show")) {
+                    positionOrderFulfillmentStatusMenu();
+                }
+                menu.toggleClass("show");
             });
             jq(document).on("click", (event) => {
                 if (!jq(event.target).closest("#orderFulfillmentStatus-filter-menu, #orderFulfillmentStatus-filter-toggle, #orderFulfillmentStatus-filter-label").length) {

--- a/omod/src/main/webapp/pages/labs/labOrderList.gsp
+++ b/omod/src/main/webapp/pages/labs/labOrderList.gsp
@@ -134,7 +134,7 @@
         // Read URL params for deep linking (e.g., Specimen Collection Queue)
         const urlParams = new URLSearchParams(window.location.search);
         const initialGrouping = urlParams.get('grouping');   // 'patient' or null
-        const initialStatuses = urlParams.getAll('status');   // e.g. ['AWAITING_FULFILLMENT', 'IN_FULFILLMENT'] or []
+        const initialStatuses = urlParams.getAll('status').filter(s => s);   // e.g. ['AWAITING_FULFILLMENT', 'IN_FULFILLMENT'] or []
 
         jq.get(openmrsContextPath + "/ws/rest/v1/pihapps/config?v=custom:(" + pihAppsConfigRep + ")", function(pihAppsConfig) {
 
@@ -240,6 +240,17 @@
                     ? "${ ui.encodeJavaScript(ui.message('pihapps.allStatuses')) }"
                     : checked.map((i, el) => jq(el).data("display")).get().join(", ");
                 jq("#orderFulfillmentStatus-filter-summary").text(summary);
+            }
+
+            const refreshActiveTable = function() {
+                const params = getFilterParameterValues();
+                if (jq("#group-by-patient-btn").hasClass("active")) {
+                    patientPagingDataTable.setParameters(params);
+                    patientPagingDataTable.goToFirstPage();
+                } else {
+                    pagingDataTable.setParameters(params);
+                    pagingDataTable.goToFirstPage();
+                }
             }
 
             const orderTableUpdated = function() {
@@ -495,6 +506,29 @@
                 });
             };
 
+            orderFulfillmentStatusOptions.forEach((statusOption) => {
+                const checkboxId = "orderFulfillmentStatus-option-" + statusOption.status;
+                const checkbox = jq("<input>").attr({
+                    type: "checkbox",
+                    id: checkboxId,
+                    value: statusOption.status,
+                    "data-display": statusOption.display
+                }).addClass("orderFulfillmentStatus-checkbox");
+                const optionLabel = jq("<label>").addClass("status-filter-option").attr("for", checkboxId)
+                    .append(checkbox).append(" " + statusOption.display);
+                jq("#orderFulfillmentStatus-filter-menu").append(optionLabel);
+            });
+            jq(".orderFulfillmentStatus-checkbox").on("change", updateOrderFulfillmentStatusSummary);
+            updateOrderFulfillmentStatusSummary();
+
+            // Apply initial status filter: URL param(s) if present, otherwise default to Ordered + Collected
+            const defaultFulfillmentStatuses = ["AWAITING_FULFILLMENT", "IN_FULFILLMENT"];
+            const statusesToApply = initialStatuses.length > 0 ? initialStatuses : defaultFulfillmentStatuses;
+            jq(".orderFulfillmentStatus-checkbox").prop("checked", function() {
+                return statusesToApply.includes(jq(this).val());
+            });
+            updateOrderFulfillmentStatusSummary();
+
             pagingDataTable.initialize({
                 tableSelector: "#orders-table",
                 tableInfoSelector: "#orders-table-info-and-paging",
@@ -530,21 +564,6 @@
                 jq("#testConcept-filter").append(optGroup);
             });
 
-            orderFulfillmentStatusOptions.forEach((statusOption) => {
-                const checkboxId = "orderFulfillmentStatus-option-" + statusOption.status;
-                const checkbox = jq("<input>").attr({
-                    type: "checkbox",
-                    id: checkboxId,
-                    value: statusOption.status,
-                    "data-display": statusOption.display
-                }).addClass("orderFulfillmentStatus-checkbox");
-                const optionLabel = jq("<label>").addClass("status-filter-option").attr("for", checkboxId)
-                    .append(checkbox).append(" " + statusOption.display);
-                jq("#orderFulfillmentStatus-filter-menu").append(optionLabel);
-            });
-            jq(".orderFulfillmentStatus-checkbox").on("change", updateOrderFulfillmentStatusSummary);
-            updateOrderFulfillmentStatusSummary();
-
             if (visitLocationUuid) {
                 const locationRep = "custom:(uuid,display,descendantLocations:(uuid,display,tags:(uuid,name)))";
                 jq.get(openmrsContextPath + "/ws/rest/v1/location/" + visitLocationUuid + "?v=" + locationRep, function(visitLocation) {
@@ -557,16 +576,7 @@
                 });
             }
 
-            jq("#test-filter-form").find(":input").change(function () {
-                const params = getFilterParameterValues();
-                if (jq("#group-by-patient-btn").hasClass("active")) {
-                    patientPagingDataTable.setParameters(params);
-                    patientPagingDataTable.goToFirstPage();
-                } else {
-                    pagingDataTable.setParameters(params);
-                    pagingDataTable.goToFirstPage();
-                }
-            });
+            jq("#test-filter-form").find(":input").change(refreshActiveTable);
 
             jq("#group-by-order-btn").on("click", function() {
                 jq(this).blur();
@@ -633,15 +643,6 @@
                 return pagingDataTable.getRowObjects().find((o) => o.uuid === orderUuid);
             }
 
-            // Apply initial status filter: URL param(s) if present, otherwise default to Ordered + Collected
-            const defaultFulfillmentStatuses = ["AWAITING_FULFILLMENT", "IN_FULFILLMENT"];
-            const statusesToApply = initialStatuses.length > 0 ? initialStatuses : defaultFulfillmentStatuses;
-            jq(".orderFulfillmentStatus-checkbox").prop("checked", function() {
-                return statusesToApply.includes(jq(this).val());
-            });
-            updateOrderFulfillmentStatusSummary();
-            jq(".orderFulfillmentStatus-checkbox").first().trigger("change");
-
             // Add clear buttons to filters
             jq(".clearable-input-wrapper").find(".icon-remove").on("click", (event) => {
                 const icon = jq(event.target);
@@ -662,7 +663,7 @@
                 event.stopPropagation();
                 jq(".orderFulfillmentStatus-checkbox").prop("checked", false);
                 updateOrderFulfillmentStatusSummary();
-                jq(".orderFulfillmentStatus-checkbox").first().trigger("change");
+                refreshActiveTable();
             });
         });
     });

--- a/omod/src/main/webapp/resources/scripts/pagingDataTable.js
+++ b/omod/src/main/webapp/resources/scripts/pagingDataTable.js
@@ -161,7 +161,11 @@ class PagingDataTable {
         });
         table.pagedTable.fnAddData([loadingRow]);
 
-        jq.get(table.endpoint, requestParameters, (data) => {
+        jq.ajax({
+            url: table.endpoint,
+            data: requestParameters,
+            traditional: true  // serialize array-valued params as repeated keys (a=1&a=2), not a[]=1&a[]=2
+        }).done((data) => {
             if (currentUpdateDate !== this.getLastUpdateDate()) {
                 return;  // This happens if a table update is requested while an existing update/search is in progress
             }

--- a/omod/src/main/webapp/resources/scripts/patientUtils.js
+++ b/omod/src/main/webapp/resources/scripts/patientUtils.js
@@ -45,7 +45,10 @@ class PihAppsPatientUtils {
     }
 
     getOrderFulfillmentStatusOption(order, orderFulfillmentStatusOptions) {
-        if (order.fulfillerStatus) {
+        // RECEIVED means fulfillment hasn't actually started yet, so it's treated the same as no
+        // fulfillerStatus at all here — matching the backend's OrderFulfillmentStatus enum, where
+        // AWAITING/EXPIRED_BEFORE/CANCELLED_BEFORE all include RECEIVED alongside null.
+        if (order.fulfillerStatus && order.fulfillerStatus !== 'RECEIVED') {
             if (order.fulfillerStatus === 'IN_PROGRESS' || order.fulfillerStatus === 'ON_HOLD') {
                 return orderFulfillmentStatusOptions.filter((option) => option.status === 'IN_FULFILLMENT')[0];
             }

--- a/omod/src/main/webapp/resources/styles/labs/labs.css
+++ b/omod/src/main/webapp/resources/styles/labs/labs.css
@@ -146,3 +146,43 @@ form input, form select, form textarea, .form input, .form select, .form textare
     font-style: italic;
     color: #555;
 }
+
+.status-filter-dropdown-wrapper {
+    position: relative;
+    display: inline-block;
+    width: 100%;
+}
+.status-filter-dropdown-toggle {
+    text-align: left;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    cursor: pointer;
+    padding-right: 1.5em;
+}
+.status-filter-clear {
+    position: absolute;
+    right: 0.5em;
+    top: 50%;
+    transform: translateY(-50%);
+    cursor: pointer;
+}
+.status-filter-dropdown-menu {
+    display: none;
+    position: absolute;
+    z-index: 10;
+    background: #fff;
+    border: 1px solid #ccc;
+    padding: 0.5em;
+    min-width: 100%;
+    white-space: nowrap;
+}
+.status-filter-dropdown-menu.show {
+    display: block;
+}
+.status-filter-option {
+    display: block;
+    font-weight: normal;
+    margin-bottom: 0.25em;
+    cursor: pointer;
+}

--- a/omod/src/main/webapp/resources/styles/labs/labs.css
+++ b/omod/src/main/webapp/resources/styles/labs/labs.css
@@ -56,8 +56,6 @@ form input, form select, form textarea, .form input, .form select, .form textare
 }
 
 #test-filter-form {
-    position: relative;
-    z-index: 1000;
     padding-bottom: 20px;
     table-layout: fixed;
 }
@@ -176,7 +174,6 @@ form input, form select, form textarea, .form input, .form select, .form textare
     background: #fff;
     border: 1px solid #ccc;
     padding: 0.5em;
-    min-width: 100%;
     white-space: nowrap;
 }
 .status-filter-dropdown-menu.show {

--- a/omod/src/main/webapp/resources/styles/labs/labs.css
+++ b/omod/src/main/webapp/resources/styles/labs/labs.css
@@ -56,6 +56,8 @@ form input, form select, form textarea, .form input, .form select, .form textare
 }
 
 #test-filter-form {
+    position: relative;
+    z-index: 1000;
     padding-bottom: 20px;
     table-layout: fixed;
 }

--- a/omod/src/main/webapp/resources/styles/labs/labs.css
+++ b/omod/src/main/webapp/resources/styles/labs/labs.css
@@ -170,7 +170,7 @@ form input, form select, form textarea, .form input, .form select, .form textare
 .status-filter-dropdown-menu {
     display: none;
     position: absolute;
-    z-index: 10;
+    z-index: 1000;
     background: #fff;
     border: 1px solid #ccc;
     padding: 0.5em;


### PR DESCRIPTION
## Summary
- Replaces the single-select Order Status dropdown on the Laboratory Orders page with a multi-select checkbox filter, defaulting to Ordered + Collected together instead of one status at a time.
- Fixes a real correctness bug in how the backend combined multiple statuses: the old query logic ORed order-statuses and fulfiller-statuses in two separate top-level clauses, which would have silently cross-contaminated results when combining statuses (e.g. Ordered + Collected could wrongly exclude legitimately-collected orders whose order was later discontinued/expired). The new logic keeps each status's own order-status/fulfiller-status scoping independent, then ORs the per-status results together.
- REST endpoints (`/ws/rest/v1/pihapps/labOrder`, `/ws/rest/v1/pihapps/patientsWithOrders`) now accept repeated `orderFulfillmentStatus` params, matching the existing `orderType`/`orderLocation` convention.
- Deep-linking via `?status=` now supports multiple repeated params (`?status=A&status=B`), backward compatible with existing single-value links.
- Fixes a pre-existing, unrelated display bug found during this work: the frontend's order-status classifier (`patientUtils.js`) disagreed with the backend for orders that were RECEIVED and later stopped/expired — it displayed "Ordered" instead of "Canceled"/"Expired". Now matches backend semantics.
- The dropdown menu renders via append-to-`<body>` positioning (the same technique jQuery UI's autocomplete widget already uses elsewhere on this page) so it isn't clipped/covered by shared page-layout CSS from outside this module.
- Removed a leftover "All" pseudo-option from the status list that no longer makes sense now that unchecking everything already means "show all statuses."

## Test plan
- [x] `mvn test` passes (24/24 backend tests, including a new regression test for the multi-status query correctness fix)
- [x] Manually verified in a local dev instance: default load (Ordered + Collected checked), adding/removing statuses, clear-all, dropdown rendering above the results table, deep links with single and multiple `status` params
- [ ] Reviewer: please click through the Laboratory Orders page filter once more before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)